### PR TITLE
Use optimize random sampling for large matches size

### DIFF
--- a/src/features/keypoints/keypoint_detection.cpp
+++ b/src/features/keypoints/keypoint_detection.cpp
@@ -78,8 +78,6 @@ namespace rgbd_slam {
 
             const Keypoint_Handler Key_Point_Extraction::compute_keypoints(const cv::Mat& grayImage, const cv::Mat& depthImage, const KeypointsWithIdStruct& lastKeypointsWithIds, const bool forceKeypointDetection) 
             {
-                assert(lastKeypointsWithIds._keypoints.size() == lastKeypointsWithIds._ids.size());
-
                 KeypointsWithIdStruct newKeypointsObject;
 
                 //detect keypoints
@@ -116,8 +114,7 @@ namespace rgbd_slam {
                 //else: No optical flow for the first frame
                 _lastFramePyramide = newImagePyramide;
 
-                const size_t opticalFlowTrackedPointCount = newKeypointsObject._keypoints.size();
-                assert(opticalFlowTrackedPointCount == newKeypointsObject._ids.size());
+                const size_t opticalFlowTrackedPointCount = newKeypointsObject.size();
 
                 /*
                  * KEY POINT DETECTION
@@ -162,8 +159,11 @@ namespace rgbd_slam {
                     }
                 }
 
+                // declare static
+                static Keypoint_Handler keypointHandler(depthImage.cols, depthImage.rows, maximumMatchDistance);
+
                 // Update last keypoint struct
-                Keypoint_Handler keypointHandler(detectedKeypoints, keypointDescriptors, newKeypointsObject, depthImage, maximumMatchDistance);
+                keypointHandler.set(detectedKeypoints, keypointDescriptors, newKeypointsObject, depthImage);
                 _meanPointExtractionDuration += (cv::getTickCount() - keypointDetectionStartTime) / static_cast<double>(cv::getTickFrequency());
                 return keypointHandler;
             }
@@ -237,8 +237,7 @@ namespace rgbd_slam {
 
                 // mark outliers as false and visualize
                 const size_t keypointSize = backwardKeypoints.size();
-                keypointStruct._ids.reserve(keypointSize);
-                keypointStruct._keypoints.reserve(keypointSize);
+                keypointStruct.reserve(keypointSize);
                 for(size_t i = 0; i < keypointSize; ++i)
                 {
                     const size_t keypointIndex = keypointIndexContainer[i];

--- a/src/features/keypoints/keypoint_handler.cpp
+++ b/src/features/keypoints/keypoint_handler.cpp
@@ -88,7 +88,7 @@ namespace rgbd_slam {
                 _descriptors = inDescriptors;
 
                 // Fill depth values, add points to image boxes
-                const size_t allKeypointSize = inKeypoints.size() + lastKeypointsWithIds._keypoints.size();
+                const size_t allKeypointSize = inKeypoints.size() + lastKeypointsWithIds.size();
                 _keypoints = std::vector<utils::ScreenCoordinate>(allKeypointSize);
 
                 // Add detected keypoints first
@@ -109,12 +109,15 @@ namespace rgbd_slam {
 
 
                 // Add optical flow keypoints then 
-                const size_t opticalPointSize = lastKeypointsWithIds._keypoints.size();
+                const size_t opticalPointSize = lastKeypointsWithIds.size();
                 for(size_t pointIndex = 0; pointIndex < opticalPointSize; ++pointIndex) {
                     const size_t newKeypointIndex = pointIndex + keypointIndexOffset;
 
                     // fill in unique point index
-                    const size_t uniqueIndex = lastKeypointsWithIds._ids[pointIndex];
+                    const KeypointsWithIdStruct::keypointWithId& kp = lastKeypointsWithIds.get(pointIndex);
+                    const size_t uniqueIndex = kp._id;
+                    const cv::Point2f& pt = kp._point;
+
                     if (uniqueIndex > 0) {
                         _uniqueIdsToKeypointIndex[uniqueIndex] = newKeypointIndex;
                     }
@@ -122,7 +125,6 @@ namespace rgbd_slam {
                         outputs::log_error("A keypoint detected by optical flow does nothave a valid keypoint id");
                     }
 
-                    const cv::Point2f& pt = lastKeypointsWithIds._keypoints[pointIndex];
                     // Depths are in millimeters, will be 0 if coordinates are invalid
                     const double depthApproximation = get_depth_approximation(depthImage, pt);
                     const utils::ScreenCoordinate vectorKeypoint(pt.x, pt.y, depthApproximation); 

--- a/src/features/keypoints/keypoint_handler.hpp
+++ b/src/features/keypoints/keypoint_handler.hpp
@@ -2,6 +2,8 @@
 #define RGBDSLAM_FEATURES_KEYPOINTS_KEYPOINTS_HANDLER_HPP
 
 #include <list>
+#include <opencv2/core/types.hpp>
+#include <utility>
 #include <vector>
 #include <opencv2/xfeatures2d.hpp>
 
@@ -29,8 +31,14 @@ namespace rgbd_slam {
              * \brief Stores a vector of keypoints, along with a vector of the unique ids associated with those keypoints in the local map
              */
             struct KeypointsWithIdStruct {
-                std::vector<cv::Point2f> _keypoints;
-                std::vector<size_t> _ids;
+                struct keypointWithId {
+                    size_t _id;
+                    cv::Point2f _point;
+
+                    keypointWithId(const size_t id, const cv::Point2f& point):
+                    _id(id), _point(point)
+                    {};
+                };
 
                 void clear()
                 {
@@ -49,6 +57,42 @@ namespace rgbd_slam {
                     assert(_keypoints.size() == _ids.size());
                     return _keypoints.size();
                 }
+
+                bool empty() const
+                {
+                    return size() == 0;
+                }
+
+                const keypointWithId get(const size_t index) const
+                {
+                    assert(index < size());
+                    return keypointWithId(_ids[index], _keypoints[index]);
+                }
+
+                void add(const size_t id, const double pointX, const double pointY)
+                {
+                    add(id, 
+                        cv::Point2f(static_cast<float>(pointX), static_cast<float>(pointY))
+                    );
+                }
+                void add(const size_t id, const cv::Point2f point)
+                {
+                    _keypoints.emplace_back(point);
+                    _ids.emplace_back(id);
+                }
+
+                const std::vector<cv::Point2f>& get_keypoints() const
+                {
+                    return _keypoints;
+                }
+                const std::vector<size_t>& get_ids() const
+                {
+                    return _ids;
+                }
+
+                private:
+                std::vector<cv::Point2f> _keypoints;
+                std::vector<size_t> _ids;
             };
 
             /**

--- a/src/features/keypoints/keypoint_handler.hpp
+++ b/src/features/keypoints/keypoint_handler.hpp
@@ -31,6 +31,24 @@ namespace rgbd_slam {
             struct KeypointsWithIdStruct {
                 std::vector<cv::Point2f> _keypoints;
                 std::vector<size_t> _ids;
+
+                void clear()
+                {
+                    _keypoints.clear();
+                    _ids.clear();
+                }
+
+                void reserve(const size_t numberOfNewKeypoints)
+                {
+                    _keypoints.reserve(numberOfNewKeypoints);
+                    _ids.reserve(numberOfNewKeypoints);
+                }
+
+                size_t size() const
+                {
+                    assert(_keypoints.size() == _ids.size());
+                    return _keypoints.size();
+                }
             };
 
             /**
@@ -40,13 +58,18 @@ namespace rgbd_slam {
             {
                 public:
                     /**
+                     * \param[in] maxMatchDistance Maximum distance to consider that a match of two points is valid
+                     */
+                    Keypoint_Handler(const uint depthImageCols, const uint depthImageRows, const double maxMatchDistance = 0.7);
+
+                    /**
+                     * \brief Set the container properties
                      * \param[in] inKeypoints New keypoints detected, no tracking informations
                      * \param[in] inDescriptors Descriptors of the new keypoints
                      * \param[in] lastKeypointsWithIds Keypoints tracked with optical flow, and their matching ids
                      * \param[in] depthImage The depth image in which those keypoints were detected
-                     * \param[in] maxMatchDistance Maximum distance to consider that a match of two points is valid
                      */
-                    Keypoint_Handler(std::vector<cv::Point2f>& inKeypoints, cv::Mat& inDescriptors, const KeypointsWithIdStruct& lastKeypointsWithIds, const cv::Mat& depthImage, const double maxMatchDistance = 0.7);
+                    void set(std::vector<cv::Point2f>& inKeypoints, cv::Mat& inDescriptors, const KeypointsWithIdStruct& lastKeypointsWithIds, const cv::Mat& depthImage);
 
                     /**
                      * \brief Get a tracking index if it exist, or -1.
@@ -122,6 +145,8 @@ namespace rgbd_slam {
                     uint get_search_space_index(const uint_pair& searchSpaceIndex) const;
                     uint get_search_space_index(const uint x, const uint y) const;
 
+                    void clear();
+
 
                 private:
                     cv::Ptr<cv::DescriptorMatcher> _featuresMatcher;
@@ -140,10 +165,8 @@ namespace rgbd_slam {
                     uint _searchSpaceCellRadius; 
 
                     // Corresponds to a 2D box containing index of key points in those boxes
-                    typedef std::list<uint> index_container;
+                    typedef std::vector<uint> index_container;
                     std::vector<index_container> _searchSpaceIndexContainer;
-
-
             };
 
         }

--- a/src/features/primitives/cylinder_segment.cpp
+++ b/src/features/primitives/cylinder_segment.cpp
@@ -314,7 +314,8 @@ namespace rgbd_slam {
             double Cylinder_Segment::get_distance(const vector3& point) const 
             {
                 double minDist = this->get_distance(point, 0);
-                for(vector3_vector::size_type i = 1; i < _pointsAxis1.size(); i++) 
+                const size_t pointAxisSize = _pointsAxis1.size();
+                for(vector3_vector::size_type i = 1; i < pointAxisSize; ++i) 
                 {
                     const double nd = this->get_distance(point, i);
                     if (minDist > nd)

--- a/src/features/primitives/primitive_detection.cpp
+++ b/src/features/primitives/primitive_detection.cpp
@@ -413,7 +413,7 @@ namespace rgbd_slam {
             {
                 //refine the coarse planes boundaries to smoother versions
                 const uint planeCount = _planeSegments.size();
-                uchar planeIdAllocator = 0;
+                planeId planeIdAllocator = 0;
                 for(uint planeIndex = 0; planeIndex < planeCount; ++planeIndex) 
                 {
                     if (planeIndex != planeMergeLabels[planeIndex])
@@ -438,7 +438,7 @@ namespace rgbd_slam {
                         continue;
 
                     // new plane ID
-                    const uchar planeId = ++planeIdAllocator;
+                    const planeId planeId = ++planeIdAllocator;
                     assert(planeId < CYLINDER_CODE_OFFSET);
 
                     //add new plane to final shapes
@@ -448,7 +448,7 @@ namespace rgbd_slam {
 
             void Primitive_Detection::add_cylinders_to_primitives(const intpair_vector& cylinderToRegionMap, cylinder_container& cylinderContainer) 
             {
-                uchar cylinderIdAllocator = CYLINDER_CODE_OFFSET;
+                cylinderId cylinderIdAllocator = CYLINDER_CODE_OFFSET;
                 for(uint cylinderIndex = 0; cylinderIndex < cylinderToRegionMap.size(); ++cylinderIndex)
                 {
                     // Build mask
@@ -466,7 +466,7 @@ namespace rgbd_slam {
                         continue;
 
                     // Affect a new cylinder id
-                    const uchar cylinderId = ++cylinderIdAllocator;
+                    const cylinderId cylinderId = ++cylinderIdAllocator;
 
                     const uint regId = cylinderToRegionMap[cylinderIndex].first;
 

--- a/src/features/primitives/primitive_detection.cpp
+++ b/src/features/primitives/primitive_detection.cpp
@@ -9,12 +9,6 @@
 #include "../../parameters.hpp"
 #include "../../outputs/logger.hpp"
 
-//index offset of a cylinder to a plane: used for masks display purposes
-const uint CYLINDER_CODE_OFFSET = 50;
-
-
-//lib simplification
-
 namespace rgbd_slam {
     namespace features {
         namespace primitives {
@@ -411,9 +405,11 @@ namespace rgbd_slam {
 
             void Primitive_Detection::add_planes_to_primitives(const uint_vector& planeMergeLabels, plane_container& planeContainer) 
             {
-                //refine the coarse planes boundaries to smoother versions
                 const uint planeCount = _planeSegments.size();
-                planeId planeIdAllocator = 0;
+                planeContainer.clear();
+                planeContainer.reserve(planeCount);
+
+                //refine the coarse planes boundaries to smoother versions
                 for(uint planeIndex = 0; planeIndex < planeCount; ++planeIndex) 
                 {
                     if (planeIndex != planeMergeLabels[planeIndex])
@@ -437,19 +433,18 @@ namespace rgbd_slam {
                     if(max <= 0 or min >= max)    //completely eroded: irrelevant plane
                         continue;
 
-                    // new plane ID
-                    const planeId planeId = ++planeIdAllocator;
-                    assert(planeId < CYLINDER_CODE_OFFSET);
-
                     //add new plane to final shapes
-                    planeContainer.emplace(planeId, Plane(_planeSegments[planeIndex], planeId, _mask));
+                    planeContainer.emplace_back(Plane(_planeSegments[planeIndex], _mask));
                 }
             }
 
             void Primitive_Detection::add_cylinders_to_primitives(const intpair_vector& cylinderToRegionMap, cylinder_container& cylinderContainer) 
             {
-                cylinderId cylinderIdAllocator = CYLINDER_CODE_OFFSET;
-                for(uint cylinderIndex = 0; cylinderIndex < cylinderToRegionMap.size(); ++cylinderIndex)
+                const size_t numberOfCylinder = cylinderToRegionMap.size();
+                cylinderContainer.clear();
+                cylinderContainer.reserve(numberOfCylinder);
+
+                for(uint cylinderIndex = 0; cylinderIndex < numberOfCylinder; ++cylinderIndex)
                 {
                     // Build mask
                     _mask = cv::Scalar(0);
@@ -465,13 +460,10 @@ namespace rgbd_slam {
                     if(max <= 0 or min >= max)    //completely eroded: irrelevant cylinder 
                         continue;
 
-                    // Affect a new cylinder id
-                    const cylinderId cylinderId = ++cylinderIdAllocator;
-
                     const uint regId = cylinderToRegionMap[cylinderIndex].first;
 
                     //add new cylinder to final shapes
-                    cylinderContainer.emplace(cylinderId, Cylinder(_cylinderSegments[regId], cylinderId, _mask));
+                    cylinderContainer.emplace_back(Cylinder(_cylinderSegments[regId], _mask));
                 }
             }
 

--- a/src/features/primitives/primitive_detection.hpp
+++ b/src/features/primitives/primitive_detection.hpp
@@ -17,9 +17,6 @@ namespace rgbd_slam {
     namespace features {
         namespace primitives {
 
-            typedef std::map<uchar, Cylinder> cylinder_container; 
-            typedef std::map<uchar, Plane> plane_container; 
-
             /**
              * \brief Main extraction class.
              * Extracts shape primitives from an organized cloud of points

--- a/src/features/primitives/shape_primitives.cpp
+++ b/src/features/primitives/shape_primitives.cpp
@@ -13,8 +13,7 @@ namespace rgbd_slam {
              *      PRIMITIVE
              *
              */
-            IPrimitive::IPrimitive(const uint id, const cv::Mat& shapeMask) :
-                _id(id),
+            IPrimitive::IPrimitive(const cv::Mat& shapeMask) :
                 _shapeMask(shapeMask.clone())
             {
                 assert(not shapeMask.empty());
@@ -46,8 +45,8 @@ namespace rgbd_slam {
              *      CYLINDER
              *
              */
-            Cylinder::Cylinder(const Cylinder_Segment& cylinderSeg, const uint id, const cv::Mat& shapeMask) :
-                IPrimitive(id, shapeMask)
+            Cylinder::Cylinder(const Cylinder_Segment& cylinderSeg, const cv::Mat& shapeMask) :
+                IPrimitive(shapeMask)
             {
                 _radius = 0;
                 for(uint i = 0; i < cylinderSeg.get_segment_count(); ++i) {
@@ -77,8 +76,8 @@ namespace rgbd_slam {
              *        PLANE
              *
              */
-            Plane::Plane(const Plane_Segment& planeSeg, const uint id, const cv::Mat& shapeMask) :
-                IPrimitive(id, shapeMask),
+            Plane::Plane(const Plane_Segment& planeSeg, const cv::Mat& shapeMask) :
+                IPrimitive(shapeMask),
 
                 _parametrization(
                     planeSeg.get_normal().x(),

--- a/src/features/primitives/shape_primitives.hpp
+++ b/src/features/primitives/shape_primitives.hpp
@@ -23,20 +23,14 @@ namespace rgbd_slam {
                 public:
                     virtual ~IPrimitive() {};
 
-                    /**
-                     * \brief Return this shape assigned id
-                     */
-                    uint get_id() const { return _id; };
-                    void set_id(const uint id) { _id = id; };
-
                     cv::Mat get_shape_mask() const { return _shapeMask; };
                     void set_shape_mask(const cv::Mat& mask) { _shapeMask = mask.clone(); };
 
                 protected:
                     /**
-                     * \brief Hidden constructor, to set _id and shape
+                     * \brief Hidden constructor, to set shape
                      */
-                    IPrimitive(const uint id, const cv::Mat& shapeMask);
+                    IPrimitive(const cv::Mat& shapeMask);
 
                     /**
                      * \brief Compute the Inter over Union factor of two masks
@@ -49,7 +43,6 @@ namespace rgbd_slam {
                     double get_IOU(const cv::Mat& mask) const;
 
                     //members
-                    uint _id;
                     cv::Mat _shapeMask;
 
                 private:
@@ -68,10 +61,9 @@ namespace rgbd_slam {
                      * \brief Construct a cylinder object
                      *
                      * \param[in] cylinderSeg Cylinder segment to copy
-                     * \param[in] id ID assigned to this shape (for tracking and debug)
                      * \param[in] shapeMask Mask of the shape in the reference image
                      */
-                    Cylinder(const Cylinder_Segment& cylinderSeg, uint id, const cv::Mat& shapeMask);
+                    Cylinder(const Cylinder_Segment& cylinderSeg, const cv::Mat& shapeMask);
 
                     /**
                      * \brief Get the similarity of two cylinders, based on normal direction and radius
@@ -104,10 +96,9 @@ namespace rgbd_slam {
                      * \brief Construct a plane object
                      *
                      * \param[in] planeSeg Plane to copy
-                     * \param[in] id ID assigned to this shape (for tracking and debug)
                      * \param[in] shapeMask Mask of the shape in the reference image
                      */
-                    Plane(const Plane_Segment& planeSeg, uint id, const cv::Mat& shapeMask);
+                    Plane(const Plane_Segment& planeSeg, const cv::Mat& shapeMask);
 
                     /**
                      * \brief Get the similarity of two planes, based on normal direction
@@ -133,12 +124,8 @@ namespace rgbd_slam {
 
 
             // types for detected primitives
-            typedef uchar cylinderId;
-            typedef std::map<cylinderId, Cylinder> cylinder_container; 
-
-            typedef uchar planeId;
-            typedef std::map<planeId, Plane> plane_container; 
-
+            typedef std::vector<Cylinder> cylinder_container; 
+            typedef std::vector<Plane> plane_container;
         }
     }
 }

--- a/src/features/primitives/shape_primitives.hpp
+++ b/src/features/primitives/shape_primitives.hpp
@@ -13,7 +13,7 @@
 namespace rgbd_slam {
     namespace features {
         namespace primitives {
-
+            
             /**
              * \brief A base class used to compute the tracking analysis.
              * It is a pure virtual class.
@@ -130,6 +130,15 @@ namespace rgbd_slam {
                     utils::PlaneCameraCoordinates _parametrization;     // infinite plane representation
                     vector3 _mean;      // mean center point of the plane; in camera coordinates
             };
+
+
+            // types for detected primitives
+            typedef uchar cylinderId;
+            typedef std::map<cylinderId, Cylinder> cylinder_container; 
+
+            typedef uchar planeId;
+            typedef std::map<planeId, Plane> plane_container; 
+
         }
     }
 }

--- a/src/map_management/local_map.cpp
+++ b/src/map_management/local_map.cpp
@@ -83,8 +83,7 @@ namespace rgbd_slam {
             features::keypoints::KeypointsWithIdStruct keypointsWithIds; 
 
             // TODO: check the efficiency gain of those reserve calls
-            keypointsWithIds._ids.reserve(numberOfNewKeypoints);
-            keypointsWithIds._keypoints.reserve(numberOfNewKeypoints);
+            keypointsWithIds.reserve(numberOfNewKeypoints);
 
             const static uint refreshFrequency = Parameters::get_keypoint_refresh_frequency();
 

--- a/src/map_management/local_map.cpp
+++ b/src/map_management/local_map.cpp
@@ -10,10 +10,7 @@
 #include "map_point.hpp"
 #include "map_primitive.hpp"
 #include "matches_containers.hpp"
-#include "primitive_detection.hpp"
-#include "shape_primitives.hpp"
 #include "types.hpp"
-#include <string>
 
 namespace rgbd_slam {
     namespace map_management {
@@ -295,7 +292,7 @@ namespace rgbd_slam {
             }
 
             // add unmatched planes to local map
-            for(const uchar& unmatchedDetectedPlaneId : _unmatchedPlaneIds)
+            for(const features::primitives::planeId& unmatchedDetectedPlaneId : _unmatchedPlaneIds)
             {
                 assert(detectedPlanes.contains(unmatchedDetectedPlaneId));
 

--- a/src/map_management/local_map.cpp
+++ b/src/map_management/local_map.cpp
@@ -402,7 +402,7 @@ namespace rgbd_slam {
             const static double maximumMatchDistance = Parameters::get_maximum_match_distance();
             const static float searchDiameter = Parameters::get_search_matches_distance();
             cv::Mat stagedPointDescriptors;
-            std::map<size_t, size_t> indexToId;
+            std::unordered_map<size_t, size_t> indexToId;
             size_t index = 0;
             for(const auto& [pointId, mapPoint] : _stagedPoints)
             {

--- a/src/map_management/local_map.cpp
+++ b/src/map_management/local_map.cpp
@@ -40,13 +40,11 @@ namespace rgbd_slam {
                 if (mapPoint._coordinates.to_screen_coordinates(worldToCamera, screenCoordinates))
                 {
                     // use previously known screen coordinates
-                    keypointsWithIds._keypoints.push_back(
-                        cv::Point2f(
-                                    static_cast<float>(screenCoordinates.x()),
-                                    static_cast<float>(screenCoordinates.y())
-                                    )
-                            );
-                    keypointsWithIds._ids.push_back(mapPoint._id);
+                    keypointsWithIds.add(
+                        mapPoint._id,
+                        screenCoordinates.x(),
+                        screenCoordinates.y()
+                    );
                 }
             }
         }

--- a/src/map_management/local_map.cpp
+++ b/src/map_management/local_map.cpp
@@ -74,6 +74,18 @@ namespace rgbd_slam {
             delete _mapWriter;
         }
 
+
+        matches_containers::matchContainer Local_Map::find_feature_matches(const utils::Pose& currentPose, const features::keypoints::Keypoint_Handler& detectedKeypointsObject, const features::primitives::plane_container& detectedPlanes)
+        {
+            matches_containers::matchContainer matchSets;
+
+            matchSets._points = find_keypoint_matches(currentPose, detectedKeypointsObject);
+            matchSets._planes = find_plane_matches(currentPose, detectedPlanes);
+
+            return matchSets;
+        }
+
+
         bool Local_Map::find_match(IMap_Point_With_Tracking& point, const features::keypoints::Keypoint_Handler& detectedKeypointsObject, const worldToCameraMatrix& worldToCamera, matches_containers::match_point_container& matchedPoints, const bool shouldAddMatchToContainer)
         {
             // try to find a match with opticalflow

--- a/src/map_management/local_map.hpp
+++ b/src/map_management/local_map.hpp
@@ -235,11 +235,11 @@ namespace rgbd_slam {
                 // Define types
 
                 // local map point container
-                typedef std::map<size_t, Map_Point> point_map_container;
+                typedef std::unordered_map<size_t, Map_Point> point_map_container;
                 // staged points container
-                typedef std::map<size_t, Staged_Point> staged_point_container;
+                typedef std::unordered_map<size_t, Staged_Point> staged_point_container;
                 // local shape plane map container
-                typedef std::map<size_t, MapPlane> plane_map_container; 
+                typedef std::unordered_map<size_t, MapPlane> plane_map_container; 
 
                 // Local map contains world points with a good confidence
                 point_map_container _localPointMap;
@@ -247,11 +247,11 @@ namespace rgbd_slam {
                 staged_point_container _stagedPoints;
                 // Hold unmatched detected point indexes, to add in the staged point container
                 std::vector<bool> _isPointMatched;
-                // Hold unmatched plane ids, to add to the local map
-                std::set<features::primitives::planeId> _unmatchedPlaneIds;
 
                 //local plane map
                 plane_map_container _localPlaneMap;
+                // Hold unmatched plane ids, to add to the local map
+                std::set<features::primitives::planeId> _unmatchedPlaneIds;
 
                 outputs::XYZ_Map_Writer* _mapWriter; 
 

--- a/src/map_management/local_map.hpp
+++ b/src/map_management/local_map.hpp
@@ -1,7 +1,6 @@
 #ifndef RGBDSLAM_MAPMANAGEMENT_LOCALMAP_HPP
 #define RGBDSLAM_MAPMANAGEMENT_LOCALMAP_HPP
 
-#include <list>
 #include <vector>
 #include <opencv2/opencv.hpp>
 #include <opencv2/xfeatures2d.hpp>
@@ -15,7 +14,7 @@
 #include "../utils/matches_containers.hpp"
 
 #include "../features/keypoints/keypoint_handler.hpp"
-#include "../features/primitives/primitive_detection.hpp"
+#include "../features/primitives/shape_primitives.hpp"
 
 
 
@@ -249,7 +248,7 @@ namespace rgbd_slam {
                 // Hold unmatched detected point indexes, to add in the staged point container
                 std::vector<bool> _isPointMatched;
                 // Hold unmatched plane ids, to add to the local map
-                std::set<uchar> _unmatchedPlaneIds;
+                std::set<features::primitives::planeId> _unmatchedPlaneIds;
 
                 //local plane map
                 plane_map_container _localPlaneMap;

--- a/src/map_management/local_map.hpp
+++ b/src/map_management/local_map.hpp
@@ -32,6 +32,8 @@ namespace rgbd_slam {
                 Local_Map();
                 ~Local_Map();
 
+                matches_containers::matchContainer find_feature_matches(const utils::Pose& currentPose, const features::keypoints::Keypoint_Handler& detectedKeypointsObject, const features::primitives::plane_container& detectedPlanes);
+
                 /**
                  * \brief Compute the point feature matches between the local map and a given set of points. Update the staged point list matched points
                  *

--- a/src/map_management/local_map.hpp
+++ b/src/map_management/local_map.hpp
@@ -251,7 +251,7 @@ namespace rgbd_slam {
                 //local plane map
                 plane_map_container _localPlaneMap;
                 // Hold unmatched plane ids, to add to the local map
-                std::set<features::primitives::planeId> _unmatchedPlaneIds;
+                std::vector<bool> _isPlaneMatched;
 
                 outputs::XYZ_Map_Writer* _mapWriter; 
 

--- a/src/map_management/map_primitive.hpp
+++ b/src/map_management/map_primitive.hpp
@@ -12,29 +12,29 @@
 namespace rgbd_slam {
     namespace map_management {
 
-        const features::primitives::planeId UNMATCHED_PRIMITIVE_ID = 0;
+        const int UNMATCHED_PRIMITIVE_ID = -1;
 
         struct MatchedPrimitive 
         {
             MatchedPrimitive():
-                _matchId(UNMATCHED_PRIMITIVE_ID),
+                _matchIndex(UNMATCHED_PRIMITIVE_ID),
                 _unmatchedCount(0)
             {};
 
             bool is_matched() const
             {
-                return _matchId != UNMATCHED_PRIMITIVE_ID;
+                return _matchIndex != UNMATCHED_PRIMITIVE_ID;
             }
 
-            void mark_matched(const features::primitives::planeId matchId)
+            void mark_matched(const uint matchIndex)
             {
-                _matchId = matchId;
+                _matchIndex = static_cast<int>(matchIndex);
                 _unmatchedCount = 0;
             }
 
             void mark_unmatched()
             {
-                _matchId = UNMATCHED_PRIMITIVE_ID;
+                _matchIndex = UNMATCHED_PRIMITIVE_ID;
                 ++_unmatchedCount;
             }
 
@@ -43,7 +43,7 @@ namespace rgbd_slam {
                 return _unmatchedCount >= Parameters::get_maximum_unmatched_before_removal();
             }
 
-            features::primitives::planeId _matchId; // Id of the last match
+            int _matchIndex; // Id of the last match
             size_t _unmatchedCount; // count of unmatched iterations
         };
 

--- a/src/map_management/map_primitive.hpp
+++ b/src/map_management/map_primitive.hpp
@@ -1,17 +1,18 @@
 #ifndef RGBDSLAM_MAPMANAGEMENT_MAPRIMITIVE_HPP
 #define RGBDSLAM_MAPMANAGEMENT_MAPRIMITIVE_HPP
 
+#include <opencv2/opencv.hpp>
+
+#include "../parameters.hpp"
 #include "../features/primitives/shape_primitives.hpp"
-#include "coordinates.hpp"
-#include "parameters.hpp"
+
 #include "../utils/random.hpp"
-#include "types.hpp"
-#include <memory>
+#include "../utils/coordinates.hpp"
 
 namespace rgbd_slam {
     namespace map_management {
 
-        const uchar UNMATCHED_PRIMITIVE_ID = 0;
+        const features::primitives::planeId UNMATCHED_PRIMITIVE_ID = 0;
 
         struct MatchedPrimitive 
         {
@@ -25,7 +26,7 @@ namespace rgbd_slam {
                 return _matchId != UNMATCHED_PRIMITIVE_ID;
             }
 
-            void mark_matched(size_t matchId)
+            void mark_matched(const features::primitives::planeId matchId)
             {
                 _matchId = matchId;
                 _unmatchedCount = 0;
@@ -42,7 +43,7 @@ namespace rgbd_slam {
                 return _unmatchedCount >= Parameters::get_maximum_unmatched_before_removal();
             }
 
-            size_t _matchId; // Id of the last match
+            features::primitives::planeId _matchId; // Id of the last match
             size_t _unmatchedCount; // count of unmatched iterations
         };
 

--- a/src/pose_optimization/levenberg_marquard_functors.cpp
+++ b/src/pose_optimization/levenberg_marquard_functors.cpp
@@ -4,7 +4,6 @@
 #include "coordinates.hpp"
 #include <Eigen/src/Core/util/Meta.h>
 #include <cmath>
-#include <iostream>
 
 namespace rgbd_slam {
     namespace pose_optimization {
@@ -106,7 +105,7 @@ namespace rgbd_slam {
             return 0;
         }
 
-        double get_transformation_score(const matches_containers::match_point_container& points, const utils::Pose& finalPose)
+        double get_transformation_score(const matches_containers::match_point_container& points, const utils::PoseBase& finalPose)
         {
             // Get the new estimated pose
             const quaternion& rotation = finalPose.get_orientation_quaternion();

--- a/src/pose_optimization/levenberg_marquard_functors.hpp
+++ b/src/pose_optimization/levenberg_marquard_functors.hpp
@@ -91,8 +91,7 @@ namespace rgbd_slam {
         /**
          * \brief Compute a mean transformation score for a pose and a set of point matches
          */
-        double get_transformation_score(const matches_containers::match_point_container& points, const utils::Pose& finalPose);
-        void get_t_score(const matches_containers::match_plane_container& planes, const utils::Pose& finalPose);
+        double get_transformation_score(const matches_containers::match_point_container& points, const utils::PoseBase& finalPose);
 
         /**
          * \brief Use for debug.

--- a/src/pose_optimization/pose_optimization.cpp
+++ b/src/pose_optimization/pose_optimization.cpp
@@ -28,7 +28,7 @@ namespace rgbd_slam {
          * \param[out] pointMatcheSets The set of inliers/outliers of this transformation
          * \return The transformation score (sum of retroprojection distances)
          */
-        double get_point_inliers_outliers(const matches_containers::match_point_container& pointsToEvaluate, const double pointMaxRetroprojectionError, const utils::Pose& transformationPose, matches_containers::point_match_sets& pointMatcheSets)
+        double get_point_inliers_outliers(const matches_containers::match_point_container& pointsToEvaluate, const double pointMaxRetroprojectionError, const utils::PoseBase& transformationPose, matches_containers::point_match_sets& pointMatcheSets)
         {
             pointMatcheSets.clear();
 
@@ -64,7 +64,7 @@ namespace rgbd_slam {
          * \param[out] planeMatchSets The set of inliers/outliers of this transformation
          * \return The transformation score
          */
-        double get_plane_inliers_outliers(const matches_containers::match_plane_container& planesToEvaluate, const double planeMaxRetroprojectionError, const utils::Pose& transformationPose, matches_containers::plane_match_sets& planeMatchSets)
+        double get_plane_inliers_outliers(const matches_containers::match_plane_container& planesToEvaluate, const double planeMaxRetroprojectionError, const utils::PoseBase& transformationPose, matches_containers::plane_match_sets& planeMatchSets)
         {
             planeMatchSets.clear();
 
@@ -92,7 +92,7 @@ namespace rgbd_slam {
             return retroprojectionScore;
         }
 
-        double get_features_inliers_outliers(const matches_containers::matchContainer& featuresToEvaluate, const double pointMaxRetroprojectionError, const double planeMaxRetroprojectionError, const utils::Pose& transformationPose, matches_containers::match_sets& featureSet)
+        double get_features_inliers_outliers(const matches_containers::matchContainer& featuresToEvaluate, const double pointMaxRetroprojectionError, const double planeMaxRetroprojectionError, const utils::PoseBase& transformationPose, matches_containers::match_sets& featureSet)
         {
             return 
                 get_point_inliers_outliers(featuresToEvaluate._points, pointMaxRetroprojectionError, transformationPose, featureSet._pointSets) +
@@ -114,7 +114,7 @@ namespace rgbd_slam {
         }
 
 
-        bool Pose_Optimization::compute_pose_with_ransac(const utils::Pose& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::Pose& finalPose, matches_containers::match_sets& featureSets) 
+        bool Pose_Optimization::compute_pose_with_ransac(const utils::PoseBase& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::PoseBase& finalPose, matches_containers::match_sets& featureSets) 
         {
             featureSets.clear();
 
@@ -162,7 +162,7 @@ namespace rgbd_slam {
 
             // set the start score to the maximum score
             double minScore = matchedPointSize * pointMaxRetroprojectionError + matchedPlaneSize * planeMaxRetroprojectionError;
-            utils::Pose bestPose = currentPose;
+            utils::PoseBase bestPose = currentPose;
             for(uint iteration = 0; iteration < maximumIterations; ++iteration)
             {
                 // get random number of planes, between minNumberOfPlanes and maxNumberOfPlanes
@@ -190,7 +190,7 @@ namespace rgbd_slam {
                 const matches_containers::match_sets& selectedMatches = get_random_subset(numberOfPointsToSample, numberOfPlanesToSample, matchedFeatures);
 
                 // compute a new candidate pose to evaluate
-                utils::Pose candidatePose;
+                utils::PoseBase candidatePose;
                 const bool isPoseValid = Pose_Optimization::compute_optimized_global_pose(currentPose, selectedMatches, candidatePose);
                 //const bool isPoseValid = Pose_Optimization::compute_p3p_pose(currentPose, selectedPointMatches, candidatePose);
                 if (not isPoseValid)
@@ -257,7 +257,7 @@ namespace rgbd_slam {
         }
 
 
-        bool Pose_Optimization::compute_optimized_global_pose(const utils::Pose& currentPose, const matches_containers::match_sets& matchedFeatures, utils::Pose& optimizedPose) 
+        bool Pose_Optimization::compute_optimized_global_pose(const utils::PoseBase& currentPose, const matches_containers::match_sets& matchedFeatures, utils::PoseBase& optimizedPose) 
         {
             const vector3& position = currentPose.get_position();    // Work in millimeters
             const quaternion& rotation = currentPose.get_orientation_quaternion();
@@ -329,7 +329,7 @@ namespace rgbd_slam {
             return true;
         }
 
-        bool Pose_Optimization::compute_p3p_pose(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, utils::Pose& optimizedPose)
+        bool Pose_Optimization::compute_p3p_pose(const utils::PoseBase& currentPose, const matches_containers::match_point_container& matchedPoints, utils::PoseBase& optimizedPose)
         {
             assert(matchedPoints.size() == 3);
             // Do all operations on meters, while this SLAM uses millimeters

--- a/src/pose_optimization/pose_optimization.cpp
+++ b/src/pose_optimization/pose_optimization.cpp
@@ -105,6 +105,8 @@ namespace rgbd_slam {
         matches_containers::match_sets get_random_subset(const uint numberOfPointsToSample, const uint numberOfPlanesToSample, const matches_containers::matchContainer& matchedFeatures)
         {
             matches_containers::match_sets matchSubset;
+            // we can have a lot of points, so use a more efficient but with potential duplicates subset
+            //matchSubset._pointSets._inliers = ransac::get_random_subset_with_duplicates(matchedFeatures._points, numberOfPointsToSample);
             matchSubset._pointSets._inliers = ransac::get_random_subset(matchedFeatures._points, numberOfPointsToSample);
             matchSubset._planeSets._inliers = ransac::get_random_subset(matchedFeatures._planes, numberOfPlanesToSample);
             assert(matchSubset._pointSets._inliers.size() == numberOfPointsToSample);
@@ -224,13 +226,13 @@ namespace rgbd_slam {
                 return false;
             }
 
-            // optimize on all inliers
+            // optimize on all inliers, starting pose is the best pose we found with RANSAC
             const bool isPoseValid = Pose_Optimization::compute_optimized_global_pose(bestPose, featureSets, finalPose);
             if (isPoseValid)
             {
                 return true;
             }
-
+            // should never happen
             outputs::log_warning("Could not compute a global pose, even though we found a valid inlier set");
             return false;
         }

--- a/src/pose_optimization/pose_optimization.hpp
+++ b/src/pose_optimization/pose_optimization.hpp
@@ -17,39 +17,38 @@ namespace rgbd_slam {
                  * \brief Compute a new observer global pose, to replace the current estimated pose 
                  *
                  * \param[in] currentPose Last observer optimized pose
-                 * \param[in] matchedPoints Object containing the match between observed screen points and reliable map & futur map points 
+                 * \param[in] matchedFeatures Object containing the match between observed screen features and reliable map features
                  * \param[out] optimizedPose The estimated world translation & rotation of the camera pose, if the function returned true
-                 * \param[out] outlierMatchedPoints The outliers matched point for the finalPose. Valid if the function returned true
-                 * \param[out] outlierMatchedPlanes The outliers matched plane for the finalPose. Valid if the function returned true
+                 * \param[out] featureSets The inliers/outliers matched features for the finalPose. Valid if the function returned true
                  *
                  * \return True if a valid pose was computed 
                  */
-                static bool compute_optimized_pose(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, const matches_containers::match_plane_container& matchedPlanes, utils::Pose& optimizedPose, matches_containers::match_sets& featureSets); 
+                static bool compute_optimized_pose(const utils::Pose& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::Pose& optimizedPose, matches_containers::match_sets& featureSets); 
 
             private:
                 /**
                  * \brief Optimize a global pose (orientation/translation) of the observer, given a match set
                  *
                  * \param[in] currentPose Last observer optimized pose
-                 * \param[in] matchedPoints Object containing the match between observed screen points and reliable map & futur map points 
+                 * \param[in] matchedFeatures Object containing the match between observed screen features and reliable map features 
                  * \param[out] optimizedPose The estimated world translation & rotation of the camera pose, if the function returned true
                  *
                  * \return True if a valid pose was computed 
                  */
-                static bool compute_optimized_global_pose(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, const matches_containers::match_plane_container& matchedPlanes, utils::Pose& optimizedPose);
+                static bool compute_optimized_global_pose(const utils::Pose& currentPose, const matches_containers::match_sets& matchedFeatures, utils::Pose& optimizedPose);
 
 
                 /**
                  * \brief Compute an optimized pose, using a RANSAC methodology
                  *
                  * \param[in] currentPose The current pose of the observer
-                 * \param[in] matchedPoints Object container the match between observed screen points and local map points 
+                 * \param[in] matchedFeatures Object container the match between observed screen features and local map features 
                  * \param[out] finalPose The optimized pose, valid if the function returned true
                  * \param[out] featureSets The matched features detected as inlier and outliers. Valid if the function returned true
                  *
                  * \return True if a valid pose and inliers were found
                  */
-                static bool compute_pose_with_ransac(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, const matches_containers::match_plane_container& matchedPlanes, utils::Pose& finalPose, matches_containers::match_sets& featureSets); 
+                static bool compute_pose_with_ransac(const utils::Pose& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::Pose& finalPose, matches_containers::match_sets& featureSets); 
 
                 static bool compute_p3p_pose(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, utils::Pose& optimizedPose);
         };

--- a/src/pose_optimization/pose_optimization.hpp
+++ b/src/pose_optimization/pose_optimization.hpp
@@ -35,7 +35,7 @@ namespace rgbd_slam {
                  *
                  * \return True if a valid pose was computed 
                  */
-                static bool compute_optimized_global_pose(const utils::Pose& currentPose, const matches_containers::match_sets& matchedFeatures, utils::Pose& optimizedPose);
+                static bool compute_optimized_global_pose(const utils::PoseBase& currentPose, const matches_containers::match_sets& matchedFeatures, utils::PoseBase& optimizedPose);
 
 
                 /**
@@ -48,9 +48,9 @@ namespace rgbd_slam {
                  *
                  * \return True if a valid pose and inliers were found
                  */
-                static bool compute_pose_with_ransac(const utils::Pose& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::Pose& finalPose, matches_containers::match_sets& featureSets); 
+                static bool compute_pose_with_ransac(const utils::PoseBase& currentPose, const matches_containers::matchContainer& matchedFeatures, utils::PoseBase& finalPose, matches_containers::match_sets& featureSets); 
 
-                static bool compute_p3p_pose(const utils::Pose& currentPose, const matches_containers::match_point_container& matchedPoints, utils::Pose& optimizedPose);
+                static bool compute_p3p_pose(const utils::PoseBase& currentPose, const matches_containers::match_point_container& matchedPoints, utils::PoseBase& optimizedPose);
         };
 
     }   /* pose_optimization */

--- a/src/pose_optimization/ransac.hpp
+++ b/src/pose_optimization/ransac.hpp
@@ -1,6 +1,7 @@
 #ifndef RGBDSLAM_POSEOPTIMIZATION_RANSAC_HPP
 #define RGBDSLAM_POSEOPTIMIZATION_RANSAC_HPP
 
+#include "../utils/random.hpp"
 #include <algorithm>
 #include <vector>
 
@@ -28,6 +29,30 @@ namespace rgbd_slam {
                     Container<T> outContainer;
                     for(uint i = 0; i < numberOfElementsToChoose; ++i)
                         outContainer.insert(outContainer.begin(), copyVector[i]);
+                    return outContainer;
+                }
+            
+            /**
+            * \brief Return a random subset of elements, of size n
+            * \param[in] inContainer A container of size > numberOfElementsToChoose, in which this function will pick elements
+            * \param[in] numberOfElementsToChoose The number of elements we which to find in the final container
+            * \return A container of size numberOfElementsToChoose
+            */
+            template< template<typename> class Container, typename T>
+                Container<T> get_random_subset_with_duplicates(const Container<T>& inContainer, const uint numberOfElementsToChoose)
+                {
+                    const uint inContainerSize = inContainer.size();
+                    assert(numberOfElementsToChoose <= inContainerSize);
+
+                    // get a vector of references
+                    std::vector<std::reference_wrapper<const T>> copyVector(inContainer.cbegin(), inContainer.cend());
+
+                    // copy the first matches, they will be randoms
+                    Container<T> outContainer;
+                    while(outContainer.size() < numberOfElementsToChoose)
+                    {
+                        outContainer.insert(outContainer.begin(), copyVector[utils::Random::get_random_uint(inContainerSize)]);
+                    }
                     return outContainer;
                 }
 

--- a/src/rgbd_slam.cpp
+++ b/src/rgbd_slam.cpp
@@ -203,8 +203,7 @@ namespace rgbd_slam {
         _meanPrimitiveTreatmentDuration += (cv::getTickCount() - primitiveDetectionStartTime) / static_cast<double>(cv::getTickFrequency());
 
         const double findMatchesStartTime = cv::getTickCount();
-        const matches_containers::match_point_container& matchedPoints = _localMap->find_keypoint_matches(refinedPose, keypointObject);
-        const matches_containers::match_plane_container& matchedPlanes = _localMap->find_plane_matches(refinedPose, detectedPlanes);
+        const matches_containers::matchContainer& matchedFeatures = _localMap->find_feature_matches(refinedPose, keypointObject, detectedPlanes);
         _meanFindMatchTime += (cv::getTickCount() - findMatchesStartTime) / static_cast<double>(cv::getTickFrequency());
 
         matches_containers::match_sets matchSets;
@@ -216,7 +215,7 @@ namespace rgbd_slam {
             const double optimizePoseStartTime = cv::getTickCount();
             utils::Pose optimizedPose;
             //if (matchedPoints.size() >= Parameters::get_minimum_point_count_for_optimization())
-            const bool isPoseValid = pose_optimization::Pose_Optimization::compute_optimized_pose(refinedPose, matchedPoints, matchedPlanes, optimizedPose, matchSets);
+            const bool isPoseValid = pose_optimization::Pose_Optimization::compute_optimized_pose(refinedPose, matchedFeatures, optimizedPose, matchSets);
             if (isPoseValid)
             {
                 refinedPose = optimizedPose;

--- a/src/rgbd_slam.cpp
+++ b/src/rgbd_slam.cpp
@@ -4,7 +4,6 @@
 
 #include "parameters.hpp"
 #include "outputs/logger.hpp"
-#include "primitive_detection.hpp"
 #include "utils/random.hpp"
 #include "utils/matches_containers.hpp"
 

--- a/src/utils/matches_containers.hpp
+++ b/src/utils/matches_containers.hpp
@@ -85,6 +85,12 @@ namespace rgbd_slam {
                 _pointSets.clear();
                 _planeSets.clear();
             }
+
+            void swap(match_sets& other)
+            {
+                _pointSets.swap(other._pointSets);
+                _planeSets.swap(other._planeSets);
+            }
         };
     }
 }

--- a/src/utils/matches_containers.hpp
+++ b/src/utils/matches_containers.hpp
@@ -46,6 +46,12 @@ namespace rgbd_slam {
                 _points.clear();
                 _planes.clear();
             }
+
+            void swap(matchContainer& other)
+            {
+                _points.swap(other._points);
+                _planes.swap(other._planes);
+            }
         };
 
 

--- a/src/utils/matches_containers.hpp
+++ b/src/utils/matches_containers.hpp
@@ -37,6 +37,17 @@ namespace rgbd_slam {
         typedef MatchTemplate<utils::PlaneCameraCoordinates, utils::PlaneWorldCoordinates, void*> PlaneMatch;
         typedef std::list<PlaneMatch> match_plane_container;
 
+        struct matchContainer {
+            match_point_container _points;
+            match_plane_container _planes;
+
+            void clear()
+            {
+                _points.clear();
+                _planes.clear();
+            }
+        };
+
 
         /**
          * \brief Store a set of inlier and a set of outliers

--- a/tests/test_pose_optimization.cpp
+++ b/tests/test_pose_optimization.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <random>
 
+#include "matches_containers.hpp"
 #include "parameters.hpp"
 #include "pose_optimization/pose_optimization.hpp"
 #include "outputs/logger.hpp"
@@ -139,8 +140,12 @@ namespace rgbd_slam {
     {
         // Compute end pose
         utils::Pose endPose; 
+        matches_containers::matchContainer matches;
+        matches._planes = matchedPlanes;
+        matches._points = matchedPoints;
+
         matches_containers::match_sets inliersOutliers;
-        const bool isPoseValid = pose_optimization::Pose_Optimization::compute_optimized_pose(initialPoseGuess, matchedPoints, matchedPlanes, endPose, inliersOutliers);
+        const bool isPoseValid = pose_optimization::Pose_Optimization::compute_optimized_pose(initialPoseGuess, matches, endPose, inliersOutliers);
 
         if (not isPoseValid)
             FAIL();


### PR DESCRIPTION
Cleanup and optimize heap usage in point detection code

Add random sampling with duplicates for large keypoint match size